### PR TITLE
Better support for boolean signals and event streams:

### DIFF
--- a/src/main/scala/io/github/makingthematrix/signals3/EventStream.scala
+++ b/src/main/scala/io/github/makingthematrix/signals3/EventStream.scala
@@ -266,6 +266,13 @@ class EventStream[E] protected () extends EventSource[E, EventSubscriber[E]]:
     */
   inline final def ifFalse(using E <:< Boolean): EventStream[Unit] = collect { case false => () }
 
+  /** Assuming that the event emitted by the stream can be interpreted as a boolean, this method creates a new event stream
+    * of type `Boolean` where each event is the opposite of the original event.
+    *
+    * @return A new event stream of `Boolean`.
+    */
+  inline final def not(using E <:< Boolean): EventStream[Boolean] = map(!_)
+
   /** By default, an event stream does not have the internal state so there's nothing to do in `onWire` and `onUnwire`*/
   override protected def onWire(): Unit = {}
 

--- a/src/test/scala/io/github/makingthematrix/signals3/EventStreamSpec.scala
+++ b/src/test/scala/io/github/makingthematrix/signals3/EventStreamSpec.scala
@@ -390,3 +390,24 @@ class EventStreamSpec extends munit.FunSuite:
     assertEquals(howMuchTrue, 3)
     assertEquals(howMuchFalse, 2)
   }
+
+  test("Flip the boolean event stream with the .not method") {
+    given dq: DispatchQueue = SerialDispatchQueue()
+
+    val booleans = List(true, false, true, false, true)
+
+    val source = EventStream[Boolean]()
+    val flipped = source.not
+    
+    var howMuchTrue = 0
+    var howMuchFalse = 0
+
+    flipped.ifTrue.foreach { _ => howMuchTrue += 1 }
+    flipped.ifFalse.foreach { _ => howMuchFalse += 1 }
+
+    booleans.foreach(source ! _)
+    awaitAllTasks
+
+    assertEquals(howMuchTrue, 2)
+    assertEquals(howMuchFalse, 3)
+  }


### PR DESCRIPTION
https://github.com/makingthematrix/signals3/issues/4

* Creation by comparison of signals values
* Logical NOT for both event streams and signals
* Methods and operators for logical AND, OR, XOR, NOR, and NAND
* Previous multi-arguments AND and OR methods in signals now get their slightly optimized two-arguments versions